### PR TITLE
PersonProjectHistory: log the specific projects being updated.

### DIFF
--- a/src/QueueReceiver.Core/Services/AccessService.cs
+++ b/src/QueueReceiver.Core/Services/AccessService.cs
@@ -116,9 +116,7 @@ namespace QueueReceiver.Core.Services
                 return;
             }
 
-            _logger.LogInformation(string.Format(
-                CultureInfo.InvariantCulture,
-                Resources.RemoveAccess, person.Id, plantId));
+            _logger.LogInformation(Resources.RemoveAccess, person.Id, plantId);
 
             await _personProjectService.RemoveAccessToPlant(person.Id, plantId);
         }

--- a/src/QueueReceiver.Core/Services/PersonProjectService.cs
+++ b/src/QueueReceiver.Core/Services/PersonProjectService.cs
@@ -86,6 +86,11 @@ namespace QueueReceiver.Core.Services
             {
                 await _personProjectHistoryRepository.AddAsync(personProjectHistory);
             }
+            else
+            {
+                _logger.LogInformation(
+                    $"Access to all projects are already voided for person {personId} and plant {plantId}. No action taken.");
+            }
         }
 
         private async Task<(List<long> updated, List<long> unvoided)> UpdatePersonProjectsAsync(long personId, List<Project> projects)

--- a/src/QueueReceiver.Infrastructure/Repositories/PersonProjectRepository.cs
+++ b/src/QueueReceiver.Infrastructure/Repositories/PersonProjectRepository.cs
@@ -28,8 +28,11 @@ namespace QueueReceiver.Infrastructure.Repositories
             var personProjects = _personProjects
                 .Include(pp => pp.Project!)
                 .ThenInclude(project => project.Plant)
-                .Where(pp => plantId.Equals(pp.Project!.PlantId)
-                             && personId == pp.PersonId);
+                .Where(pp =>
+                    plantId.Equals(pp.Project!.PlantId)
+                    && !pp.IsVoided
+                    && personId == pp.PersonId);
+
             personProjects.ForEachAsync(pp => pp.IsVoided = true);
 
             return personProjects.ToList();


### PR DESCRIPTION
Avoid cluttering the project history log when access already exist, or already voided.