### PR TITLE
User naming updates from AD

### DIFF
--- a/GroupSyncer/GroupSyncer.csproj
+++ b/GroupSyncer/GroupSyncer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>7206b070-321a-4946-8524-980b2eeb7af6</UserSecretsId>

--- a/src/QueueReceiver.Core/Interfaces/IPersonService.cs
+++ b/src/QueueReceiver.Core/Interfaces/IPersonService.cs
@@ -14,5 +14,6 @@ namespace QueueReceiver.Core.Interfaces
         Task<IEnumerable<string>> GetMembersWithOidAndAccessToPlant(string plantId);
         Task SetPersonCreatedByCache();
         Task UpdateVoidedStatus(string personOid);
+        (string, string) GetAdPersonFirstAndLastName(AdPerson adPerson);
     }
 }

--- a/src/QueueReceiver.Core/Interfaces/IPersonService.cs
+++ b/src/QueueReceiver.Core/Interfaces/IPersonService.cs
@@ -14,6 +14,6 @@ namespace QueueReceiver.Core.Interfaces
         Task<IEnumerable<string>> GetMembersWithOidAndAccessToPlant(string plantId);
         Task SetPersonCreatedByCache();
         Task UpdateVoidedStatus(string personOid);
-        (string, string) GetAdPersonFirstAndLastName(AdPerson adPerson);
+        (string firstName, string lastName) GetAdPersonFirstAndLastName(AdPerson adPerson);
     }
 }

--- a/src/QueueReceiver.Core/Models/AdPerson.cs
+++ b/src/QueueReceiver.Core/Models/AdPerson.cs
@@ -15,6 +15,7 @@
         public string GivenName { get; set; } = null!;
         public string Surname { get; set; } = null!;
         public string MobileNumber { get; set; } = null!;
+        public string DisplayName { get; set; } = null!;
         public bool IsDeleted { get; set; }
 
     }

--- a/src/QueueReceiver.Core/Services/GraphService.cs
+++ b/src/QueueReceiver.Core/Services/GraphService.cs
@@ -51,18 +51,27 @@ namespace QueueReceiver.Core.Services
             {
                 var user = await graphClient.Users[userOid].Request().GetAsync();
 
-                var email = user.Mail;
+                // username is e-mail by default
+                var userName = user.Mail;
+                var email = userName;
 
-                if (string.IsNullOrEmpty(email) && user.UserPrincipalName.Contains("@"))
+                if (string.IsNullOrEmpty(userName))
                 {
-                    email = user.UserPrincipalName;
+                    // set UserPrincipalName if e-mail is undefined
+                    userName = user.UserPrincipalName;
+
+                    if (userName.Contains("@"))
+                    {
+                        email = userName;
+                    }
                 }
 
-                var adPerson = new AdPerson(user.Id, user.UserPrincipalName, email)
+                var adPerson = new AdPerson(user.Id, userName, email)
                 {
                     GivenName = user.GivenName,
                     Surname = user.Surname,
-                    MobileNumber = user.MobilePhone
+                    MobileNumber = user.MobilePhone,
+                    DisplayName = user.DisplayName
                 };
 
                 return adPerson;

--- a/src/QueueReceiver.Core/Services/GraphService.cs
+++ b/src/QueueReceiver.Core/Services/GraphService.cs
@@ -53,16 +53,16 @@ namespace QueueReceiver.Core.Services
 
                 // username is e-mail by default
                 var userName = user.Mail;
-                var email = userName;
+                var email = user.Mail;
 
                 if (string.IsNullOrEmpty(userName))
                 {
                     // set UserPrincipalName if e-mail is undefined
                     userName = user.UserPrincipalName;
 
-                    if (userName.Contains("@"))
+                    if (user.UserPrincipalName.Contains("@"))
                     {
-                        email = userName;
+                        email = user.UserPrincipalName;
                     }
                 }
 

--- a/src/QueueReceiver.Core/Services/PersonService.cs
+++ b/src/QueueReceiver.Core/Services/PersonService.cs
@@ -211,7 +211,7 @@ namespace QueueReceiver.Core.Services
                 });
         }
 
-        public (string, string) GetAdPersonFirstAndLastName(AdPerson adPerson)
+        public (string firstName, string lastName) GetAdPersonFirstAndLastName(AdPerson adPerson)
         {
             if (!string.IsNullOrEmpty(adPerson.GivenName) && !string.IsNullOrEmpty(adPerson.Surname))
             {

--- a/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
+++ b/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <VersionPrefix>1.0.6</VersionPrefix>
+    <VersionPrefix>1.0.7</VersionPrefix>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>dotnet-QueueReceiverService-07627E4F-C4B5-47B4-AF2D-E17B095E695C</UserSecretsId>
     <PublishSingleFile>true</PublishSingleFile>

--- a/tests/QueueReceiver.Core.UnitTests/Services/PersonServiceTests.cs
+++ b/tests/QueueReceiver.Core.UnitTests/Services/PersonServiceTests.cs
@@ -98,5 +98,45 @@ namespace QueueReceiver.Core.UnitTests.Services
             //Assert
             Assert.IsNull(person);
         }
+
+        [TestMethod]
+        public void GetAdPersonNameFromGivenAndSurname()
+        {
+            // Arrange
+            const string testGivenName = "TestGivenName";
+            const string testSurname = "TestSurname";
+
+            var adPerson = new AdPerson("oid", "username", "email")
+            {
+                GivenName = testGivenName,
+                Surname = testSurname
+            };
+
+            // Act
+            var (firstName, lastName) = _service.GetAdPersonFirstAndLastName(adPerson);
+
+            // Assert
+            Assert.AreEqual(testGivenName, firstName);
+            Assert.AreEqual(testSurname, lastName);
+        }
+
+        [TestMethod]
+        public void GetAdPersonNameFromDisplayName()
+        {
+            // Arrange
+            const string testDisplayName = "Jul E Nissen";
+
+            var adPerson = new AdPerson("oid", "username", "email")
+            {
+                DisplayName = testDisplayName
+            };
+
+            // Act
+            var (firstName, lastName) = _service.GetAdPersonFirstAndLastName(adPerson);
+
+            // Assert
+            Assert.AreEqual("Jul E", firstName);
+            Assert.AreEqual("Nissen", lastName);
+        }
     }
 }


### PR DESCRIPTION
1. Set username = e-mail when available, otherwise UPN. 
2. Get first/last name from Given/Surname when available, otherwise DisplayName.