### PR TITLE
Update name used for user lookup

### DIFF
--- a/GroupSyncer/GroupSyncer.csproj
+++ b/GroupSyncer/GroupSyncer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>7206b070-321a-4946-8524-980b2eeb7af6</UserSecretsId>

--- a/src/QueueReceiver.Core/Services/PersonService.cs
+++ b/src/QueueReceiver.Core/Services/PersonService.cs
@@ -108,8 +108,6 @@ namespace QueueReceiver.Core.Services
                 throw new Exception($"{userOid} not found in graph. Queue out of sync ");
             }
 
-            // TODO: test Sverre sin QA bruker, hvorfor slo reconcile ikke til?
-
             if (adPerson.MobileNumber != null
                 && ((adPerson.GivenName != null && adPerson.Surname != null)
                     || adPerson.DisplayName != null))
@@ -140,7 +138,7 @@ namespace QueueReceiver.Core.Services
             {
                 _logger.LogInformation($"Reconcile: setting OID {userOid} on {reconcilePersons.Count} possible matches.");
 
-                reconcilePersons.ForEach(rp=> rp.Reconcile = userOid);
+                reconcilePersons.ForEach(rp => rp.Reconcile = userOid);
                 return;
             }
 

--- a/src/QueueReceiver.Core/Services/PersonService.cs
+++ b/src/QueueReceiver.Core/Services/PersonService.cs
@@ -160,7 +160,8 @@ namespace QueueReceiver.Core.Services
 
         private async Task<Person?> FindAndUpdateAsync(AdPerson adPerson)
         {
-            if (adPerson.MobileNumber == null || ((adPerson.GivenName == null && adPerson.Surname == null) || adPerson.DisplayName == null))
+            if (adPerson.MobileNumber == null ||
+                ((adPerson.GivenName == null && adPerson.Surname == null) || adPerson.DisplayName == null))
             {
                 return null;
             }

--- a/src/QueueReceiver.Infrastructure/Repositories/PersonRepository.cs
+++ b/src/QueueReceiver.Infrastructure/Repositories/PersonRepository.cs
@@ -70,6 +70,8 @@ namespace QueueReceiver.Infrastructure.Repositories
             string lastName, 
             string userName)
         {
+            userName = userName.ToUpper();
+
             var shortName = string.IsNullOrEmpty(userName) || !userName.Contains("@")
                 ? string.Empty
                 : userName.Substring(0, userName.IndexOf('@')).ToUpper();

--- a/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
+++ b/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <VersionPrefix>1.0.7</VersionPrefix>
+    <VersionPrefix>1.0.8</VersionPrefix>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>dotnet-QueueReceiverService-07627E4F-C4B5-47B4-AF2D-E17B095E695C</UserSecretsId>
     <PublishSingleFile>true</PublishSingleFile>


### PR DESCRIPTION
For various user lookups - get first and last name from AD person DisplayName, when given/surname is not available (external users).