### PR TITLE
Add email to reconcile matching

### DIFF
--- a/src/QueueReceiver.Core/Services/PersonService.cs
+++ b/src/QueueReceiver.Core/Services/PersonService.cs
@@ -196,10 +196,10 @@ namespace QueueReceiver.Core.Services
 
             // In order to set reconcile, the existing and new users e-mail domains must match.
             // Otherwise, it is most likely a new affiliate user and should not be reconciled.
-            // Defaults to EQUINOR.COM if username is not an e-mail address ("short name").
             foreach (var person in possibleMatches.ToList())
             {
-                var reconcilePersonEmailDomain = GetEmailAddressDomain(person.UserName);
+                var reconcilePersonEmail = person.UserName.Contains("@") ? person.UserName : person.Email;
+                var reconcilePersonEmailDomain = GetEmailAddressDomain(reconcilePersonEmail);
 
                 if (adPersonEmailDomain == reconcilePersonEmailDomain)
                 {


### PR DESCRIPTION
Reconcile matching person check - fallback to person.Email when username is not an e-mail address.