### PR TITLE
Automatic update of 18 packages

### DIFF
--- a/GroupSyncer/GroupSyncer.csproj
+++ b/GroupSyncer/GroupSyncer.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.14.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.4" />
   </ItemGroup>
 

--- a/GroupSyncer/GroupSyncer.csproj
+++ b/GroupSyncer/GroupSyncer.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.14.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.4" />
   </ItemGroup>

--- a/GroupSyncer/GroupSyncer.csproj
+++ b/GroupSyncer/GroupSyncer.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.14.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/QueueReceiver.Core/QueueReceiver.Core.csproj
+++ b/src/QueueReceiver.Core/QueueReceiver.Core.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Graph" Version="3.12.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.7" />
-    <PackageReference Include="Oracle.EntityFrameworkCore" Version="2.19.70" />
+    <PackageReference Include="Oracle.EntityFrameworkCore" Version="2.19.80" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/QueueReceiver.Core/QueueReceiver.Core.csproj
+++ b/src/QueueReceiver.Core/QueueReceiver.Core.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/QueueReceiver.Core/QueueReceiver.Core.csproj
+++ b/src/QueueReceiver.Core/QueueReceiver.Core.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.7" />
     <PackageReference Include="Microsoft.Graph" Version="3.12.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="2.19.80" />

--- a/src/QueueReceiver.Core/QueueReceiver.Core.csproj
+++ b/src/QueueReceiver.Core/QueueReceiver.Core.csproj
@@ -14,7 +14,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Graph" Version="3.12.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.7" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="2.19.80" />
   </ItemGroup>
 

--- a/src/QueueReceiver.Core/QueueReceiver.Core.csproj
+++ b/src/QueueReceiver.Core/QueueReceiver.Core.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Graph" Version="3.6.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.12.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.7" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="2.19.70" />
   </ItemGroup>

--- a/src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj
+++ b/src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.4" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
   </ItemGroup>

--- a/src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj
+++ b/src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.7" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj
+++ b/src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj
+++ b/src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.7" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
   </ItemGroup>
 

--- a/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
+++ b/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.14.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
+++ b/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
@@ -23,7 +23,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.7" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
   </ItemGroup>
   

--- a/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
+++ b/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />

--- a/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
+++ b/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
   </ItemGroup>

--- a/tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj
+++ b/tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />

--- a/tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj
+++ b/tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">

--- a/tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj
+++ b/tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj
+++ b/tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj
+++ b/tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="MockQueryable.Moq" Version="3.1.3" />
-    <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">

--- a/tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj
+++ b/tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="MockQueryable.Moq" Version="3.1.3" />
     <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj
+++ b/tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="MockQueryable.Moq" Version="3.1.3" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />

--- a/tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj
+++ b/tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="MockQueryable.Moq" Version="3.1.3" />
     <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
+++ b/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
+++ b/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
+++ b/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />

--- a/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
+++ b/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">

--- a/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
+++ b/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.14.5" />

--- a/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
+++ b/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />


### PR DESCRIPTION
18 packages were updated in 7 projects:
`MSTest.TestAdapter`, `MSTest.TestFramework`, `Moq`, `Microsoft.CodeAnalysis.FxCopAnalyzers`, `Microsoft.Extensions.Configuration.FileExtensions`, `Microsoft.Extensions.Configuration.Json`, `Microsoft.Extensions.Configuration.UserSecrets`, `Microsoft.NET.Test.Sdk`, `Microsoft.EntityFrameworkCore.InMemory`, `Microsoft.Graph`, `Oracle.EntityFrameworkCore`, `Microsoft.IdentityModel.Clients.ActiveDirectory`, `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Configuration.Abstractions`, `Microsoft.Extensions.Hosting.Abstractions`, `Microsoft.Extensions.Hosting`, `Microsoft.Extensions.Hosting.WindowsServices`, `System.Data.SqlClient`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `MSTest.TestAdapter` to `2.1.2` from `2.1.1`
`MSTest.TestAdapter 2.1.2` was published at `2020-06-08T11:13:21Z`, 3 months ago

3 project updates:
Updated `tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj` to `MSTest.TestAdapter` `2.1.2` from `2.1.1`
Updated `tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj` to `MSTest.TestAdapter` `2.1.2` from `2.1.1`
Updated `tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj` to `MSTest.TestAdapter` `2.1.2` from `2.1.1`

[MSTest.TestAdapter 2.1.2 on NuGet.org](https://www.nuget.org/packages/MSTest.TestAdapter/2.1.2)

NuKeeper has generated a patch update of `MSTest.TestFramework` to `2.1.2` from `2.1.1`
`MSTest.TestFramework 2.1.2` was published at `2020-06-08T11:13:30Z`, 3 months ago

3 project updates:
Updated `tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj` to `MSTest.TestFramework` `2.1.2` from `2.1.1`
Updated `tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj` to `MSTest.TestFramework` `2.1.2` from `2.1.1`
Updated `tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj` to `MSTest.TestFramework` `2.1.2` from `2.1.1`

[MSTest.TestFramework 2.1.2 on NuGet.org](https://www.nuget.org/packages/MSTest.TestFramework/2.1.2)

NuKeeper has generated a patch update of `Moq` to `4.14.5` from `4.14.1`
`Moq 4.14.5` was published at `2020-07-01T16:48:50Z`, 2 months ago

3 project updates:
Updated `tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj` to `Moq` `4.14.5` from `4.14.1`
Updated `tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj` to `Moq` `4.14.5` from `4.14.1`
Updated `tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj` to `Moq` `4.14.5` from `4.14.1`

[Moq 4.14.5 on NuGet.org](https://www.nuget.org/packages/Moq/4.14.5)

NuKeeper has generated a minor update of `Microsoft.CodeAnalysis.FxCopAnalyzers` to `3.3.0` from `3.0.0`
`Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.0` was published at `2020-08-10T19:51:45Z`, 24 days ago

3 project updates:
Updated `src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj` to `Microsoft.CodeAnalysis.FxCopAnalyzers` `3.3.0` from `3.0.0`
Updated `src/QueueReceiver.Core/QueueReceiver.Core.csproj` to `Microsoft.CodeAnalysis.FxCopAnalyzers` `3.3.0` from `3.0.0`
Updated `src/QueueReceiver.Worker/QueueReceiver.Worker.csproj` to `Microsoft.CodeAnalysis.FxCopAnalyzers` `3.3.0` from `3.0.0`

[Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/3.3.0)

NuKeeper has generated a patch update of `Microsoft.Extensions.Configuration.FileExtensions` to `3.1.7` from `3.1.4`
`Microsoft.Extensions.Configuration.FileExtensions 3.1.7` was published at `2020-08-11T14:16:51Z`, 23 days ago

1 project update:
Updated `GroupSyncer/GroupSyncer.csproj` to `Microsoft.Extensions.Configuration.FileExtensions` `3.1.7` from `3.1.4`

[Microsoft.Extensions.Configuration.FileExtensions 3.1.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.FileExtensions/3.1.7)

NuKeeper has generated a patch update of `Microsoft.Extensions.Configuration.Json` to `3.1.7` from `3.1.4`
`Microsoft.Extensions.Configuration.Json 3.1.7` was published at `2020-08-11T14:16:16Z`, 23 days ago

1 project update:
Updated `GroupSyncer/GroupSyncer.csproj` to `Microsoft.Extensions.Configuration.Json` `3.1.7` from `3.1.4`

[Microsoft.Extensions.Configuration.Json 3.1.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Json/3.1.7)

NuKeeper has generated a patch update of `Microsoft.Extensions.Configuration.UserSecrets` to `3.1.7` from `3.1.4`
`Microsoft.Extensions.Configuration.UserSecrets 3.1.7` was published at `2020-08-11T14:17:12Z`, 23 days ago

3 project updates:
Updated `GroupSyncer/GroupSyncer.csproj` to `Microsoft.Extensions.Configuration.UserSecrets` `3.1.7` from `3.1.4`
Updated `src/QueueReceiver.Worker/QueueReceiver.Worker.csproj` to `Microsoft.Extensions.Configuration.UserSecrets` `3.1.7` from `3.1.4`
Updated `tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj` to `Microsoft.Extensions.Configuration.UserSecrets` `3.1.7` from `3.1.4`

[Microsoft.Extensions.Configuration.UserSecrets 3.1.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.UserSecrets/3.1.7)

NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `16.7.1` from `16.6.1`
`Microsoft.NET.Test.Sdk 16.7.1` was published at `2020-08-20T09:25:54Z`, 14 days ago

3 project updates:
Updated `tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj` to `Microsoft.NET.Test.Sdk` `16.7.1` from `16.6.1`
Updated `tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj` to `Microsoft.NET.Test.Sdk` `16.7.1` from `16.6.1`
Updated `tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj` to `Microsoft.NET.Test.Sdk` `16.7.1` from `16.6.1`

[Microsoft.NET.Test.Sdk 16.7.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.7.1)

NuKeeper has generated a major update of `Microsoft.EntityFrameworkCore.InMemory` to `3.1.7` from `2.2.6`
`Microsoft.EntityFrameworkCore.InMemory 3.1.7` was published at `2020-08-11T14:15:39Z`, 23 days ago

1 project update:
Updated `tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj` to `Microsoft.EntityFrameworkCore.InMemory` `3.1.7` from `2.2.6`

[Microsoft.EntityFrameworkCore.InMemory 3.1.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.InMemory/3.1.7)

NuKeeper has generated a minor update of `Microsoft.Graph` to `3.12.0` from `3.6.0`
`Microsoft.Graph 3.12.0` was published at `2020-08-26T04:57:09Z`, 8 days ago

1 project update:
Updated `src/QueueReceiver.Core/QueueReceiver.Core.csproj` to `Microsoft.Graph` `3.12.0` from `3.6.0`

[Microsoft.Graph 3.12.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Graph/3.12.0)

NuKeeper has generated a patch update of `Oracle.EntityFrameworkCore` to `2.19.80` from `2.19.70`
`Oracle.EntityFrameworkCore 2.19.80` was published at `2020-07-09T02:38:04Z`, 2 months ago

1 project update:
Updated `src/QueueReceiver.Core/QueueReceiver.Core.csproj` to `Oracle.EntityFrameworkCore` `2.19.80` from `2.19.70`

[Oracle.EntityFrameworkCore 2.19.80 on NuGet.org](https://www.nuget.org/packages/Oracle.EntityFrameworkCore/2.19.80)

NuKeeper has generated a patch update of `Microsoft.IdentityModel.Clients.ActiveDirectory` to `5.2.8` from `5.2.7`
`Microsoft.IdentityModel.Clients.ActiveDirectory 5.2.8` was published at `2020-06-30T14:43:03Z`, 3 months ago

1 project update:
Updated `src/QueueReceiver.Core/QueueReceiver.Core.csproj` to `Microsoft.IdentityModel.Clients.ActiveDirectory` `5.2.8` from `5.2.7`

[Microsoft.IdentityModel.Clients.ActiveDirectory 5.2.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.IdentityModel.Clients.ActiveDirectory/5.2.8)

NuKeeper has generated a patch update of `Microsoft.Extensions.DependencyInjection.Abstractions` to `3.1.7` from `3.1.4`
`Microsoft.Extensions.DependencyInjection.Abstractions 3.1.7` was published at `2020-08-11T14:16:58Z`, 23 days ago

1 project update:
Updated `src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj` to `Microsoft.Extensions.DependencyInjection.Abstractions` `3.1.7` from `3.1.4`

[Microsoft.Extensions.DependencyInjection.Abstractions 3.1.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions/3.1.7)

NuKeeper has generated a patch update of `Microsoft.Extensions.Configuration.Abstractions` to `3.1.7` from `3.1.4`
`Microsoft.Extensions.Configuration.Abstractions 3.1.7` was published at `2020-08-11T14:16:36Z`, 23 days ago

1 project update:
Updated `src/QueueReceiver.Core/QueueReceiver.Core.csproj` to `Microsoft.Extensions.Configuration.Abstractions` `3.1.7` from `3.1.4`

[Microsoft.Extensions.Configuration.Abstractions 3.1.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Abstractions/3.1.7)

NuKeeper has generated a patch update of `Microsoft.Extensions.Hosting.Abstractions` to `3.1.7` from `3.1.4`
`Microsoft.Extensions.Hosting.Abstractions 3.1.7` was published at `2020-08-11T14:17:17Z`, 23 days ago

1 project update:
Updated `src/QueueReceiver.Worker/QueueReceiver.Worker.csproj` to `Microsoft.Extensions.Hosting.Abstractions` `3.1.7` from `3.1.4`

[Microsoft.Extensions.Hosting.Abstractions 3.1.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Hosting.Abstractions/3.1.7)

NuKeeper has generated a patch update of `Microsoft.Extensions.Hosting` to `3.1.7` from `3.1.4`
`Microsoft.Extensions.Hosting 3.1.7` was published at `2020-08-11T14:16:44Z`, 23 days ago

1 project update:
Updated `src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj` to `Microsoft.Extensions.Hosting` `3.1.7` from `3.1.4`

[Microsoft.Extensions.Hosting 3.1.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Hosting/3.1.7)

NuKeeper has generated a patch update of `Microsoft.Extensions.Hosting.WindowsServices` to `3.1.7` from `3.1.4`
`Microsoft.Extensions.Hosting.WindowsServices 3.1.7` was published at `2020-08-11T14:17:05Z`, 23 days ago

1 project update:
Updated `src/QueueReceiver.Worker/QueueReceiver.Worker.csproj` to `Microsoft.Extensions.Hosting.WindowsServices` `3.1.7` from `3.1.4`

[Microsoft.Extensions.Hosting.WindowsServices 3.1.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Hosting.WindowsServices/3.1.7)

NuKeeper has generated a patch update of `System.Data.SqlClient` to `4.8.2` from `4.8.1`
`System.Data.SqlClient 4.8.2` was published at `2020-08-11T14:15:16Z`, 23 days ago

1 project update:
Updated `src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj` to `System.Data.SqlClient` `4.8.2` from `4.8.1`

[System.Data.SqlClient 4.8.2 on NuGet.org](https://www.nuget.org/packages/System.Data.SqlClient/4.8.2)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
