### PR TITLE
Update async handling

### DIFF
--- a/GroupSyncer/GroupSyncer.csproj
+++ b/GroupSyncer/GroupSyncer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.0.12</VersionPrefix>
+    <VersionPrefix>1.0.13</VersionPrefix>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>7206b070-321a-4946-8524-980b2eeb7af6</UserSecretsId>

--- a/src/QueueReceiver.Core/Services/AccessService.cs
+++ b/src/QueueReceiver.Core/Services/AccessService.cs
@@ -63,7 +63,7 @@ namespace QueueReceiver.Core.Services
 
         public async Task UpdateMemberInfo(List<Member> members, string plantId)
         {
-            var tasks = members.Select(async member =>
+            foreach (var member in members)
             {
                 if (member.ShouldVoid)
                 {
@@ -72,16 +72,15 @@ namespace QueueReceiver.Core.Services
                 else
                 {
                     await _personService.CreateIfNotExist(member.UserOid, plantId);
-                }
-            });
+                }                
+            }
 
-            await Task.WhenAll(tasks);
             await _unitOfWork.SaveChangesAsync();
         }
 
         public async Task UpdateMemberAccess(List<Member> members, string plantId)
         {
-            var tasks = members.Select(async member =>
+            foreach (var member in members)
             {
                 if (member.ShouldVoid)
                 {
@@ -91,20 +90,18 @@ namespace QueueReceiver.Core.Services
                 {
                     await GiveAccess(member.UserOid, plantId);
                 }
-            });
+            }
 
-            await Task.WhenAll(tasks);
             await _unitOfWork.SaveChangesAsync();
         }
 
         public async Task UpdateMemberVoidedStatus(List<Member> members)
         {
-            var tasks = members.Select(async member =>
+            foreach (var member in members)
             {
                 await _personService.UpdateVoidedStatus(member.UserOid);
-            });
+            }
 
-            await Task.WhenAll(tasks);
             await _unitOfWork.SaveChangesAsync();
         }
 

--- a/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
+++ b/src/QueueReceiver.Worker/QueueReceiver.Worker.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <VersionPrefix>1.0.18</VersionPrefix>
+    <VersionPrefix>1.0.19</VersionPrefix>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>dotnet-QueueReceiverService-07627E4F-C4B5-47B4-AF2D-E17B095E695C</UserSecretsId>
     <PublishSingleFile>true</PublishSingleFile>


### PR DESCRIPTION
Update async handling to avoid multiple threads accessing the same db context simultaneously (changed after EF Core update started failing).