### PR TITLE
Automatic update of 4 packages

### DIFF
--- a/src/QueueReceiver.Core/QueueReceiver.Core.csproj
+++ b/src/QueueReceiver.Core/QueueReceiver.Core.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/QueueReceiver.Core/QueueReceiver.Core.csproj
+++ b/src/QueueReceiver.Core/QueueReceiver.Core.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Graph" Version="3.21.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.22.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="3.19.80" />
   </ItemGroup>

--- a/src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj
+++ b/src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj
+++ b/tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Moq" Version="4.15.2" />
+    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">

--- a/tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj
+++ b/tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="MockQueryable.Moq" Version="5.0.0" />
-    <PackageReference Include="Moq" Version="4.15.2" />
+    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">

--- a/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
+++ b/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Moq" Version="4.15.2" />
+    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">

--- a/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
+++ b/tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.16.0" />


### PR DESCRIPTION
4 packages were updated in 5 projects:
`Moq`, `Microsoft.Azure.ServiceBus`, `Microsoft.Graph`, `Microsoft.EntityFrameworkCore.InMemory`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Moq` to `4.16.0` from `4.15.2`
`Moq 4.16.0` was published at `2021-01-16T14:16:08Z`, 12 days ago

3 project updates:
Updated `tests/QueueReceiver.Core.UnitTests/QueueReceiver.Core.UnitTests.csproj` to `Moq` `4.16.0` from `4.15.2`
Updated `tests/QueueReceiver.Infrastructure.UnitTests/QueueReceiver.Infrastructure.UnitTests.csproj` to `Moq` `4.16.0` from `4.15.2`
Updated `tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj` to `Moq` `4.16.0` from `4.15.2`

[Moq 4.16.0 on NuGet.org](https://www.nuget.org/packages/Moq/4.16.0)

NuKeeper has generated a patch update of `Microsoft.Azure.ServiceBus` to `5.1.1` from `5.1.0`
`Microsoft.Azure.ServiceBus 5.1.1` was published at `2021-01-13T21:00:29Z`, 15 days ago

2 project updates:
Updated `src/QueueReceiver.Core/QueueReceiver.Core.csproj` to `Microsoft.Azure.ServiceBus` `5.1.1` from `5.1.0`
Updated `src/QueueReceiver.Infrastructure/QueueReceiver.Infrastructure.csproj` to `Microsoft.Azure.ServiceBus` `5.1.1` from `5.1.0`

[Microsoft.Azure.ServiceBus 5.1.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.Azure.ServiceBus/5.1.1)

NuKeeper has generated a minor update of `Microsoft.Graph` to `3.22.0` from `3.21.0`
`Microsoft.Graph 3.22.0` was published at `2021-01-20T22:34:29Z`, 8 days ago

1 project update:
Updated `src/QueueReceiver.Core/QueueReceiver.Core.csproj` to `Microsoft.Graph` `3.22.0` from `3.21.0`

[Microsoft.Graph 3.22.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Graph/3.22.0)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.InMemory` to `5.0.2` from `5.0.1`
`Microsoft.EntityFrameworkCore.InMemory 5.0.2` was published at `2021-01-12T14:38:56Z`, 16 days ago

1 project update:
Updated `tests/QueueReceiver.IntegrationTests/QueueReceiver.IntegrationTests.csproj` to `Microsoft.EntityFrameworkCore.InMemory` `5.0.2` from `5.0.1`

[Microsoft.EntityFrameworkCore.InMemory 5.0.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.InMemory/5.0.2)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
